### PR TITLE
Add nvim-cmp and coq as dependencies in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,10 @@ To get started with `blade-nav.nvim`, add the plugin to your `init.lua` or `init
 ```lua
 use {
     'ricardoramirezr/blade-nav.nvim',
+    requires = {
+        'hrsh7th/nvim-cmp', -- if using nvim-cmp
+        { "ms-jpq/coq_nvim", branch = "coq" }, -- if using coq
+    },
     ft = {'blade', 'php'}
 }
 ```
@@ -66,6 +70,10 @@ use {
 ```lua
 {
     'ricardoramirezr/blade-nav.nvim',
+    dependencies = {
+        'hrsh7th/nvim-cmp', -- if using nvim-cmp
+        { "ms-jpq/coq_nvim", branch = "coq" }, -- if using coq
+    },
     ft = {'blade', 'php'} -- optional, improves startup time
 }
 ```


### PR DESCRIPTION
This PR adds nvim-cmp and coq in installation section of the README for Lazy and Packer.

Thanks for making this plugin!