### PR TITLE
Remove --columns from route:list

### DIFF
--- a/lua/blade-nav/utils.lua
+++ b/lua/blade-nav/utils.lua
@@ -82,15 +82,12 @@ M.in_table = function(needle, table)
 end
 
 M.get_route_names = function()
-  local obj = vim
-      .system({
-        "php",
-        "artisan",
-        "route:list",
-        "--json",
-        "--columns=name",
-      }, { text = true })
-      :wait()
+  local obj = vim.system({
+    "php",
+    "artisan",
+    "route:list",
+    "--json",
+  }, { text = true }):wait()
 
   if obj.code ~= 0 then
     vim.notify("Error running artisan route:list")


### PR DESCRIPTION
Looks like this isn't an option and trying to use the cmp for route(' will die here https://github.com/RicardoRamirezR/blade-nav.nvim/blob/main/lua/blade-nav/utils.lua#L96
![image](https://github.com/user-attachments/assets/e11a3a8f-d17c-4c8b-86a0-0a205a963f53)
