### PR TITLE
Failing to find module using gf

### DIFF
--- a/lua/blade-nav/gf.lua
+++ b/lua/blade-nav/gf.lua
@@ -253,7 +253,7 @@ local function gf_module(prefix)
 
   for _, gf in ipairs(gfs) do
     if utils.in_table(prefix, gf.prefixes) then
-      return gf.fn
+      return "blade-nav." .. gf.fn
     end
   end
 end
@@ -267,8 +267,7 @@ function M.gf()
 
   local fn = gf_module(prefix)
   if fn then
-    local module_name = "blade-nav." .. fn
-    local module = package.loaded[module_name] or require(module_name)
+    local module = package.loaded[fn] or require(fn)
 
     if module and type(module.gf) == "function" then
       return pcall(module.gf, component_name)

--- a/lua/blade-nav/gf.lua
+++ b/lua/blade-nav/gf.lua
@@ -267,7 +267,8 @@ function M.gf()
 
   local fn = gf_module(prefix)
   if fn then
-    local module = package.loaded[fn] or require(fn)
+    local module_name = "blade-nav." .. fn
+    local module = package.loaded[module_name] or require(module_name)
 
     if module and type(module.gf) == "function" then
       return pcall(module.gf, component_name)


### PR DESCRIPTION
Using the goto file seems to blow up, It looks like when we try to require the files we aren't prefixing it with blade-nav so its' looking into the default lua paths

Using gf on a view
```
E5108: Error executing lua: /home/vagrant/blade-nav.nvim/lua/blade-nav/gf.lua:270: module 'gf_views' not found:
        no field package.preload['gf_views']
cache_loader: module gf_views not found
cache_loader_lib: module gf_views not found
        no file './gf_views.lua'
        no file '/home/vagrant/neovim/.deps/usr/share/luajit-2.1/gf_views.lua'
        no file '/usr/local/share/lua/5.1/gf_views.lua'
        no file '/usr/local/share/lua/5.1/gf_views/init.lua'
        no file '/home/vagrant/neovim/.deps/usr/share/lua/5.1/gf_views.lua'
        no file '/home/vagrant/neovim/.deps/usr/share/lua/5.1/gf_views/init.lua'
        no file '/home/vagrant/.local/share/nvim/lazy-rocks/telescope.nvim/share/lua/5.1/gf_views.lua'
        no file '/home/vagrant/.local/share/nvim/lazy-rocks/telescope.nvim/share/lua/5.1/gf_views/init.lua'
        no file './gf_views.so'
        no file '/usr/local/lib/lua/5.1/gf_views.so'
        no file '/home/vagrant/neovim/.deps/usr/lib/lua/5.1/gf_views.so'
        no file '/usr/local/lib/lua/5.1/loadall.so'
        no file '/home/vagrant/.local/share/nvim/lazy-rocks/telescope.nvim/lib/lua/5.1/gf_views.so'
stack traceback:
        [C]: in function 'require'
        /home/vagrant/blade-nav.nvim/lua/blade-nav/gf.lua:270: in function 'gf'
        /home/vagrant/blade-nav.nvim/lua/blade-nav/gf.lua:344: in function </home/vagrant/blade-nav.nvim/lua/blade-nav/gf.lua:342
>
```

Using gf on a route
```
E5108: Error executing lua: ...ocal/share/nvim/lazy/blade-nav.nvim/lua/blade-nav/gf.lua:270: module 'gf_routes' not found:
        no field package.preload['gf_routes']
cache_loader: module gf_routes not found
cache_loader_lib: module gf_routes not found
        no file './gf_routes.lua'
        no file '/home/vagrant/neovim/.deps/usr/share/luajit-2.1/gf_routes.lua'
        no file '/usr/local/share/lua/5.1/gf_routes.lua'
        no file '/usr/local/share/lua/5.1/gf_routes/init.lua'
        no file '/home/vagrant/neovim/.deps/usr/share/lua/5.1/gf_routes.lua'
        no file '/home/vagrant/neovim/.deps/usr/share/lua/5.1/gf_routes/init.lua'
        no file '/home/vagrant/.local/share/nvim/lazy-rocks/telescope.nvim/share/lua/5.1/gf_routes.lua'
        no file '/home/vagrant/.local/share/nvim/lazy-rocks/telescope.nvim/share/lua/5.1/gf_routes/init.lua'
        no file './gf_routes.so'
        no file '/usr/local/lib/lua/5.1/gf_routes.so'
        no file '/home/vagrant/neovim/.deps/usr/lib/lua/5.1/gf_routes.so'
        no file '/usr/local/lib/lua/5.1/loadall.so'
        no file '/home/vagrant/.local/share/nvim/lazy-rocks/telescope.nvim/lib/lua/5.1/gf_routes.so'
stack traceback:
        [C]: in function 'require'
        ...ocal/share/nvim/lazy/blade-nav.nvim/lua/blade-nav/gf.lua:270: in function 'gf'
        ...ocal/share/nvim/lazy/blade-nav.nvim/lua/blade-nav/gf.lua:344: in function <...ocal/share/nvim/lazy/blade-nav.nvim/lua/blade-nav/gf.lua:342>
```