### PR TITLE
feat: add support for to_route

### DIFF
--- a/lua/blade-nav/cmp.lua
+++ b/lua/blade-nav/cmp.lua
@@ -33,23 +33,7 @@ M.setup = function()
   end
 
   source.get_keyword_pattern = function()
-    local components_keywords = {
-      "<x-",
-      "<livewire:",
-    }
-    local functions_keywords = {
-      "@extends",
-      "@include",
-      "@livewire",
-      "route",
-      "view",
-      "View::make",
-      "Route::view",
-    }
-    local functions_pattern = [[\(]] .. table.concat(functions_keywords, "\\|") .. [[\)\(('\)*\w*]]
-    local components_pattern = [[\(]] .. table.concat(components_keywords, "\\|") .. [[\)\w*]]
-
-    return functions_pattern .. [[\|]] .. components_pattern
+    return utils.get_keyword_pattern()
   end
 
   source.complete = function(_, request, callback)

--- a/lua/blade-nav/utils.lua
+++ b/lua/blade-nav/utils.lua
@@ -173,6 +173,7 @@ end
 
 M.get_view_names = function(input)
   local patterns = {
+    { pattern = "to_route%(",    tpl = "to_route('%s')",           ft = { "blade", "php" }, fn = find_routes },
     { pattern = "route%(",       tpl = "route('%s')",              ft = { "blade", "php" }, fn = find_routes },
     { pattern = "<x%-",          tpl = "<x-%s />",                 ft = "blade",            fn = find_components },
     { pattern = "<livewire",     tpl = "<livewire:%s />",          ft = "blade",            fn = find_livewire },
@@ -215,6 +216,7 @@ M.get_keyword_pattern = function()
     "@include",
     "@livewire",
     "route",
+    "to_route",
     "view",
     "View::make",
     "Route::view",
@@ -230,14 +232,14 @@ M.get_root_and_lang = function()
   local parser = parsers.get_parser()
 
   if not parser then
-    vim.notify("Failed to parse the tree.", vim.lsp.log_levels.ERROR)
+    vim.notify("Failed to parse the tree.", vim.log.levels.ERROR)
     return nil, nil
   end
 
   local tree = parser:parse()[1]
 
   if not tree then
-    vim.notify("Failed to parse the tree.", vim.lsp.log_levels.ERROR)
+    vim.notify("Failed to parse the tree.", vim.log.levels.ERROR)
     return nil, nil
   end
 


### PR DESCRIPTION
This adds support for to_route() this is the same as doing `redirect(route())` or `redirect()->route()`, the current code when trying to use cmp would remove `to_` so you'd only have `route('something')` instead of `to_route('something')`

I also updated the errors to use int since it was complaining and updated cmp to use the utils helper to reduce code duplication.