### PR TITLE
Fix rename componet by component vars that give nil error

### DIFF
--- a/BladeNav.php
+++ b/BladeNav.php
@@ -12,7 +12,7 @@ class BladeNav extends Command
      *
      * @var string
      */
-    protected $description = 'List view componets aliases';
+    protected $description = 'List view components aliases';
 
     /**
      * The name and signature of the console command.

--- a/README.md
+++ b/README.md
@@ -167,7 +167,7 @@ of the supported files, i.e.:
 
 ```lua
 vim.g.blade_nav = {
-  laravel_componets = {
+  laravel_components = {
     "resources/views/common",
   },
 }

--- a/lua/blade-nav/gf.lua
+++ b/lua/blade-nav/gf.lua
@@ -412,8 +412,8 @@ local function laravel_component(component_name)
     class = { "app/View/Components/" .. capitalize(component_name) .. ".php" },
   }
 
-  if vim.g.blade_nav and vim.g.blade_nav.laravel_componets then
-    for _, path in ipairs(vim.g.blade_nav.laravel_componets) do
+  if vim.g.blade_nav and vim.g.blade_nav.laravel_components then
+    for _, path in ipairs(vim.g.blade_nav.laravel_components) do
       table.insert(paths.components, #paths.components + 1, path .. "/" .. component_name .. ".blade.php")
     end
   end
@@ -429,7 +429,7 @@ end
 local function laravel_view(component_name)
   component_name = component_name:gsub("['()%)]", "")
   return {
-    componets = { "resources/views/" .. component_name .. ".blade.php" },
+    components = { "resources/views/" .. component_name .. ".blade.php" },
     class = { nil },
   }
 end
@@ -437,7 +437,7 @@ end
 local function livewire_component(component_name)
   component_name = component_name:gsub("['()%)]", "")
   return {
-    componets = { "resources/views/livewire/" .. component_name .. ".blade.php" },
+    components = { "resources/views/livewire/" .. component_name .. ".blade.php" },
     class = { "app/Http/Livewire/" .. utils.kebab_to_pascal(component_name) .. ".php" },
   }
 end
@@ -479,7 +479,7 @@ local function package_component(text)
   text = utils.explode(",", text)
   local package_name, component_name = check_for_filament_support(text)
   return {
-    componets = { "vendor/" .. package_name .. "/resources/views/components/" .. component_name .. ".blade.php" },
+    components = { "vendor/" .. package_name .. "/resources/views/components/" .. component_name .. ".blade.php" },
     class = { nil },
   }
 end

--- a/lua/blade-nav/health.lua
+++ b/lua/blade-nav/health.lua
@@ -118,13 +118,13 @@ local function check_setup()
     warn("Git repository not found")
   end
 
-  if vim.g.blade_nav and vim.g.blade_nav.laravel_componets then
-    local s_or_not = #vim.g.blade_nav.laravel_componets > 1 and "s" or ""
+  if vim.g.blade_nav and vim.g.blade_nav.laravel_components then
+    local s_or_not = #vim.g.blade_nav.laravel_components > 1 and "s" or ""
     ok(
       "Additional search path"
       .. s_or_not
       .. " for Laravel components "
-      .. table.concat(vim.g.blade_nav.laravel_componets, '", "')
+      .. table.concat(vim.g.blade_nav.laravel_components, '", "')
       .. '"'
     )
   end


### PR DESCRIPTION
This fix the error in return of functions:
- laravel_view
- livewire_component
- package_component
The keys that were being retrieved from the table were returning an incorrect key name, specifically 'componet' instead of the expected 'component' which gave a nil error when trying to find the view file
![image](https://github.com/user-attachments/assets/86e8cd30-99c8-4760-bd54-8a35fd162389)


Additionally, the name of the global variable for custom components was corrected, as it incorrectly read 'componet' instead of the correct 'component'