### PR TITLE
Fix not_close_tag option

### DIFF
--- a/lua/blade-nav/cmp.lua
+++ b/lua/blade-nav/cmp.lua
@@ -11,7 +11,7 @@ M.setup = function(opts)
     return
   end
 
-  M.not_close_tag = not (opts.close_tag_on_complete or true)
+  M.not_close_tag = not (opts.close_tag_on_complete ~= false)
 
   registered = true
 


### PR DESCRIPTION
This should fix #25 

The PR should preserve the original behavior of being with close tags by default. 

Without the option (default):
```lua
M.not_close_tag = not (nil ~= false)
M.not_close_tag = not (true)
M.not_close_tag = false
```
With the option `true`
```lua
M.not_close_tag = not (true ~= false)
M.not_close_tag = not (true)
M.not_close_tag = false
```
With the option `false`
```lua
M.not_close_tag = not (false != false)
M.not_close_tag = not (false)
M.not_close_tag = true
```