### PR TITLE
Fix potential issue with cmp

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,6 +175,31 @@ vim.g.blade_nav = {
 
 See `:h VIMINIT`
 
+## Customization with nvim-cmp
+
+If you want to add an icon to blade-nav completion items in cmp, you can configure it through nvim-cmp's formatting options:
+
+```
+local kind_icons = {
+    BladeNav = "", 
+}
+
+local cmp = require('cmp')
+
+cmp.setup({
+  formatting = {
+    format = function(entry, item)
+
+      if kind_icons[item.kind] then
+        item.kind = string.format('%s %s', kind_icons[item.kind], item.kind)
+      end
+
+      return item
+    end
+  },
+})
+```
+
 ## Health
 
 To check the health of the plugin, run `:checkhealth blade-nav`.

--- a/lua/blade-nav/cmp.lua
+++ b/lua/blade-nav/cmp.lua
@@ -50,7 +50,7 @@ M.setup = function(opts)
         label = name.label,
         cmp = {
           kind_hl_group = "CmpItemKindBladeNav",
-          kind_text = "  " .. " blade-nav",
+          kind_text = "BladeNav",
         },
         textEdit = {
           newText = name.newText,


### PR DESCRIPTION
I won't be much appreciated with this PR. It's fine to not merge it.
But In my opinion this issue raise a valid concern, however I'm still learning lua/nvim, I only have a limited knowledge, so take this PR with a grain of salt.

Until this PR https://github.com/NvChad/ui/pull/382, the plugin couldn't be used at all with [NvChad](https://nvchad.com/)
Now, it's working, but with some limitations.

There is two issues: 
First one was an unexpected kind (this one is fixed)
The second is still a remaining issue related to NvChad because it creates an invalid `menu_hl_group` since there's a concatenation of the name:  https://github.com/NvChad/ui/blob/cfafe4aeb7b5d7ffde097d3d8df61289e33a6d51/lua/nvchad/cmp/init.lua#L15 So, depending of cmp style we choose in NvChad, it may crash nvim.

I assume by convention it should be name the same `CmpItemKind%KIND_NAME%` : https://github.com/hrsh7th/nvim-cmp/blob/29fb4854573355792df9e156cb779f0d31308796/doc/cmp.txt#L403-L408

> *CmpItemKind%KIND_NAME%*
  Highlight group for the kind of the field for a specific `lsp.CompletionItemKind`.
  If you only want to overwrite the `method` kind's highlight group, you can do this:
>vim
    highlight CmpItemKindMethod guibg=NONE guifg=Orange
<

Also, there's an aesthetic reason: cmp is highly customizable and it can offer customization for the users. In it's current state, it's a bit  strange to see the icon on the right, meanwhile all other icons are on the left. 
![2024-10-24_17-21](https://github.com/user-attachments/assets/293bb77c-ec6b-4cec-a37e-d6cd2e099ca1)

Take against this PR: 
- Now it will look ugly by default in CMP and you will have to configure the icon yourself
- The icon should be added to the pre-configured nvim such has NvChad (author is ok to add `BladeNav` icon), possibly (Lazyvim?)
- I can make my own fork if I'm not happy with the default icon (and that's fine) :laughing: 

