### PR TITLE
feat(config): add include_routes option to control completion scope

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,7 @@ use {
     ft = {'blade', 'php'}, -- optional, improves startup time
     opts = {
         close_tag_on_complete = true, -- default: true
+        include_routes = true, -- default: true
     },
 }
 ```
@@ -156,6 +157,12 @@ For completion to place nice with autopairs, you can set the
 
 ```lua
   close_tag_on_complete = false, -- default: true
+```
+
+For the plugin to include routes in the search, you can set the `include_routes` to false.
+
+```lua
+  include_routes = false, -- default: true
 ```
 
 For packages that has Blade components, you should run the Ex command

--- a/README.md
+++ b/README.md
@@ -93,7 +93,6 @@ use {
     ft = {'blade', 'php'}, -- optional, improves startup time
     opts = {
         close_tag_on_complete = true, -- default: true
-        include_routes = true, -- default: true
     },
 }
 ```
@@ -159,12 +158,6 @@ For completion to place nice with autopairs, you can set the
   close_tag_on_complete = false, -- default: true
 ```
 
-For the plugin to include routes in the search, you can set the `include_routes` to false.
-
-```lua
-  include_routes = false, -- default: true
-```
-
 For packages that has Blade components, you should run the Ex command
 `BladeNavInstallArtisanCommand` to install the artisan command.
 
@@ -177,6 +170,14 @@ vim.g.blade_nav = {
   laravel_components = {
     "resources/views/common",
   },
+}
+```
+
+If you want to disable routes completion, you can set the `include_routes` option to `false`.
+
+```lua
+vim.g.blade_nav = {
+  include_routes = false
 }
 ```
 

--- a/lua/blade-nav/cmp.lua
+++ b/lua/blade-nav/cmp.lua
@@ -3,7 +3,6 @@ local utils = require("blade-nav.utils")
 
 local M = {}
 M.not_close_tag = false
-M.include_routes = true
 
 local registered = false
 
@@ -13,7 +12,6 @@ M.setup = function(opts)
   end
 
   M.not_close_tag = not (opts.close_tag_on_complete ~= false)
-  M.include_routes = (opts.include_routes ~= false)
 
   registered = true
 
@@ -38,7 +36,7 @@ M.setup = function(opts)
   end
 
   source.get_keyword_pattern = function()
-    return utils.get_keyword_pattern(M.include_routes)
+    return utils.get_keyword_pattern()
   end
 
   source.complete = function(_, request, callback)

--- a/lua/blade-nav/cmp.lua
+++ b/lua/blade-nav/cmp.lua
@@ -3,6 +3,7 @@ local utils = require("blade-nav.utils")
 
 local M = {}
 M.not_close_tag = false
+M.include_routes = true
 
 local registered = false
 
@@ -12,6 +13,7 @@ M.setup = function(opts)
   end
 
   M.not_close_tag = not (opts.close_tag_on_complete ~= false)
+  M.include_routes = (opts.include_routes ~= false)
 
   registered = true
 
@@ -36,7 +38,7 @@ M.setup = function(opts)
   end
 
   source.get_keyword_pattern = function()
-    return utils.get_keyword_pattern()
+    return utils.get_keyword_pattern(M.include_routes)
   end
 
   source.complete = function(_, request, callback)

--- a/lua/blade-nav/health.lua
+++ b/lua/blade-nav/health.lua
@@ -129,7 +129,7 @@ local function check_setup()
     )
   end
 
-  if vim.g.blade_nav then
+  if vim.g.blade_nav and vim.g.blade_nav.include_routes then
     if type(vim.g.blade_nav.include_routes) ~= "boolean" then
       warn("Include routes should be boolean")
     end

--- a/lua/blade-nav/health.lua
+++ b/lua/blade-nav/health.lua
@@ -128,6 +128,13 @@ local function check_setup()
       .. '"'
     )
   end
+
+  if vim.g.blade_nav then
+    if type(vim.g.blade_nav.include_routes) ~= "boolean" then
+      warn("Include routes should be boolean")
+    end
+    ok("Include routes: " .. (vim.g.blade_nav.include_routes and "true" or "false"))
+  end
 end
 
 M.check = function()

--- a/lua/blade-nav/utils.lua
+++ b/lua/blade-nav/utils.lua
@@ -325,9 +325,8 @@ M.get_view_names = function(input, not_include_closing_tag)
 end
 
 --- Get keyword pattern
---- @param include_routes boolean
 --- @return string
-M.get_keyword_pattern = function(include_routes)
+M.get_keyword_pattern = function()
   local components_keywords = {
     "<x-",
     "<livewire:",
@@ -342,8 +341,8 @@ M.get_keyword_pattern = function(include_routes)
     "View::make",
     "Route::view",
   }
-  
-  if not include_routes then
+
+  if vim.g.blade_nav and not vim.g.blade_nav.include_routes then
     functions_keywords = vim.tbl_filter(function(keyword)
       return not M.in_table(keyword, { "route", "to_route" })
     end, functions_keywords)

--- a/lua/blade-nav/utils.lua
+++ b/lua/blade-nav/utils.lua
@@ -325,8 +325,9 @@ M.get_view_names = function(input, not_include_closing_tag)
 end
 
 --- Get keyword pattern
+--- @param include_routes boolean
 --- @return string
-M.get_keyword_pattern = function()
+M.get_keyword_pattern = function(include_routes)
   local components_keywords = {
     "<x-",
     "<livewire:",
@@ -341,6 +342,13 @@ M.get_keyword_pattern = function()
     "View::make",
     "Route::view",
   }
+  
+  if not include_routes then
+    functions_keywords = vim.tbl_filter(function(keyword)
+      return not M.in_table(keyword, { "route", "to_route" })
+    end, functions_keywords)
+  end
+  
   local functions_pattern = [[\(]] .. table.concat(functions_keywords, "\\|") .. [[\)\(('\)*\w*]]
   local components_pattern = [[\(]] .. table.concat(components_keywords, "\\|") .. [[\)\w*]]
 


### PR DESCRIPTION
Hallo. This PR adds a new configuration option `include_routes` that allows to exclude route completions from the search results. 

If you want to know why I created this? That's because I got slow completion when I type `route('`, but I don't think that's an issue for some people, so I don't create issue for it, maybe I just got spec issue :). But I think it would be better to make the scope of completion customizable, in this case the routes.

Here is the changes i made:
- Added new `include_routes` option (defaults to true)
- Modified `get_keyword_pattern` function to filter out route patterns when `include_routes` is false
- Updated README with documentation for the new option
