### PR TITLE
Fix component name not found when no trailing characters on line

### DIFF
--- a/lua/blade-nav/gf.lua
+++ b/lua/blade-nav/gf.lua
@@ -271,7 +271,7 @@ local function find_name(text_input, col)
 
   local text = text_input:gsub("%s+", " ")
   col = col - (#text_input - #text)
-  local start_pos, end_pos = text:find("[,%s>%)]", col)
+  local start_pos, end_pos = text:find("[,%s>%)]", col) or text:find("$", col), text:find("$", col)
   if not start_pos then
     return
   end


### PR DESCRIPTION
See #35.