### PR TITLE
Suppress error when there's no blade component file name under cursor

### DIFF
--- a/lua/blade-nav/gf.lua
+++ b/lua/blade-nav/gf.lua
@@ -26,7 +26,9 @@ local function gf_native()
     local rhs = vim.api.nvim_replace_termcodes(gf_mapping.rhs, true, true, true)
     vim.api.nvim_feedkeys(rhs, "n", false)
   else
-    vim.fn.execute("normal! gf")
+    pcall(function()
+      vim.fn.execute("normal! gf")
+    end)
   end
 end
 


### PR DESCRIPTION
fix #41

 - Wrapped the native `gf` call in a `pcall()` to catch and suppress the error, allowing the operation to fail silently instead of displaying an error message to the user.
