### PR TITLE
fix: fallback to unpack if table.unpack is not available

### DIFF
--- a/lua/blade-nav/features/annotations/hover.lua
+++ b/lua/blade-nav/features/annotations/hover.lua
@@ -2,7 +2,7 @@ local M = {}
 
 local uv = vim.loop
 local ts = vim.treesitter
-local unpack = table.unpack
+local unpack = table.unpack or unpack
 local log = require("blade-nav.utils.log")
 local textnode = require("blade-nav.core.textnode")
 local lang_extractor = require("blade-nav.extractors.lang")


### PR DESCRIPTION
This PR fixes the following error when using the hover feature on nvim `>= 0.12`

```bash
E5108: Lua: ...de-nav.nvim/lua/blade-nav/features/annotations/hover.lua:173: attempt to call upvalue 'unpack' (a nil value)
```


According to [this `hrsh7th/nvim-cmp` discussion](https://github.com/hrsh7th/nvim-cmp/issues/1017#issuecomment-1141440976), this is due to Neovim using Lua 5.1 as it's internal Lua.

>After some more research, it seems that Neovim currently uses Lua 5.1 as it's internal Lua, which is why it doesn't recognize table.unpack as this deprecation occurs in 5.2