### PR TITLE
fix(fs): detect nested Laravel project roots

### DIFF
--- a/lua/blade-nav/integrations/health.lua
+++ b/lua/blade-nav/integrations/health.lua
@@ -97,7 +97,7 @@ local function check_project_files()
   local root_dir = fs.get_root_dir()
   if not root_dir or root_dir == "" then
     root_dir = vim.fn.getcwd()
-    warn("Could not detect Git root, fallback to cwd: " .. root_dir)
+    warn("Could not detect Laravel or Git root, fallback to cwd: " .. root_dir)
   end
 
   if laravel.is_laravel_project(root_dir) then

--- a/lua/blade-nav/utils/fs.lua
+++ b/lua/blade-nav/utils/fs.lua
@@ -7,12 +7,22 @@ local cache = require("blade-nav.utils.cache")
 local M = {}
 
 --- Get the root directory of the project.
+--- Prefers the nearest Laravel root (artisan marker) relative to the current
+--- buffer, then the Git repository root, then the current working directory.
 --- @return string
 function M.get_root_dir()
-  local cache_key = "root_dir"
+  local buf_name = vim.api.nvim_buf_get_name(0)
+  local start = buf_name ~= "" and buf_name or vim.fn.getcwd()
+
+  local cache_key = "root_dir:" .. start
   local cached = cache.get(cache_key)
   if cached then
     return cached
+  end
+
+  local laravel_root = vim.fs.root(0, "artisan")
+  if laravel_root then
+    return cache.set(cache_key, laravel_root)
   end
 
   local root_dir, ok = cmd.execute_silent({ "git", "rev-parse", "--show-toplevel" })

--- a/lua/tests/test_fs_spec.lua
+++ b/lua/tests/test_fs_spec.lua
@@ -20,7 +20,9 @@ describe("fs.get_root_dir", function()
   before_each(function()
     real_execute_silent = cmd.execute_silent
     cache.clear()
-    tmpdir = uv.fs_mkdtemp("/tmp/blade-nav-root-test-XXXXXX")
+		tmpdir = assert(
+			uv.fs_realpath(uv.fs_mkdtemp("/tmp/blade-nav-root-test-XXXXXX"))
+		)
     assert.is_truthy(tmpdir)
   end)
 

--- a/lua/tests/test_fs_spec.lua
+++ b/lua/tests/test_fs_spec.lua
@@ -1,6 +1,121 @@
 local cmd = require("blade-nav.utils.cmd")
 local fs = require("blade-nav.utils.fs")
+local cache = require("blade-nav.utils.cache")
 local uv = vim.uv
+
+describe("fs.get_root_dir", function()
+  local real_execute_silent
+  local tmpdir
+
+  local function write_file(path, content)
+    local fd = assert(uv.fs_open(path, "w", 420))
+    uv.fs_write(fd, content, -1)
+    uv.fs_close(fd)
+  end
+
+  local function mkdir(path)
+    vim.fn.mkdir(path, "p", 493)
+  end
+
+  before_each(function()
+    real_execute_silent = cmd.execute_silent
+    cache.clear()
+    tmpdir = uv.fs_mkdtemp("/tmp/blade-nav-root-test-XXXXXX")
+    assert.is_truthy(tmpdir)
+  end)
+
+  after_each(function()
+    cmd.execute_silent = real_execute_silent
+    vim.api.nvim_buf_set_name(0, "")
+    cache.clear()
+
+    local function rmdir(path)
+      local fd = uv.fs_scandir(path)
+      if fd then
+        while true do
+          local name, t = uv.fs_scandir_next(fd)
+          if not name then
+            break
+          end
+          local full = path .. "/" .. name
+          if t == "directory" then
+            rmdir(full)
+          else
+            uv.fs_unlink(full)
+          end
+        end
+      end
+      uv.fs_rmdir(path)
+    end
+    rmdir(tmpdir)
+  end)
+
+  it("finds the nearest Laravel root (artisan marker) in a monorepo", function()
+    mkdir(tmpdir .. "/monorepo/scripts/resources/views")
+    write_file(tmpdir .. "/monorepo/scripts/artisan", "")
+    vim.api.nvim_buf_set_name(0, tmpdir .. "/monorepo/scripts/resources/views/home.blade.php")
+
+    assert.are.equal(tmpdir .. "/monorepo/scripts", fs.get_root_dir())
+  end)
+
+  it("does not reuse a cached Laravel root for a buffer outside the app", function()
+    mkdir(tmpdir .. "/monorepo/scripts/resources/views")
+    write_file(tmpdir .. "/monorepo/scripts/artisan", "")
+    vim.api.nvim_buf_set_name(0, tmpdir .. "/monorepo/scripts/resources/views/home.blade.php")
+    assert.are.equal(tmpdir .. "/monorepo/scripts", fs.get_root_dir())
+
+    cmd.execute_silent = function(command, opts)
+      if command[1] == "git" and command[2] == "rev-parse" then
+        return tmpdir .. "/monorepo", true
+      end
+      return real_execute_silent(command, opts)
+    end
+
+    vim.api.nvim_buf_set_name(0, tmpdir .. "/monorepo/assets/app.css")
+    assert.are.equal(tmpdir .. "/monorepo", fs.get_root_dir())
+  end)
+
+  it("falls back to the git root when no Laravel root is found", function()
+    mkdir(tmpdir .. "/repo/app/Models")
+    vim.api.nvim_buf_set_name(0, tmpdir .. "/repo/app/Models/User.php")
+
+    cmd.execute_silent = function(command, opts)
+      if command[1] == "git" and command[2] == "rev-parse" then
+        return tmpdir .. "/repo", true
+      end
+      return real_execute_silent(command, opts)
+    end
+
+    assert.are.equal(tmpdir .. "/repo", fs.get_root_dir())
+  end)
+
+  it("falls back to cwd when neither Laravel root nor git root is found", function()
+    mkdir(tmpdir .. "/plain")
+    vim.api.nvim_buf_set_name(0, tmpdir .. "/plain/file.txt")
+
+    cmd.execute_silent = function(command, opts)
+      if command[1] == "git" and command[2] == "rev-parse" then
+        return "fatal: not a git repository", false
+      end
+      return real_execute_silent(command, opts)
+    end
+
+    assert.are.equal(vim.fn.getcwd(), fs.get_root_dir())
+  end)
+
+  it("uses cwd as start when the buffer is unnamed", function()
+    vim.api.nvim_buf_set_name(0, "")
+
+    cmd.execute_silent = function(command, opts)
+      if command[1] == "git" and command[2] == "rev-parse" then
+        return "fatal: not a git repository", false
+      end
+      return real_execute_silent(command, opts)
+    end
+
+    assert.are.equal(vim.fn.getcwd(), fs.get_root_dir())
+  end)
+end)
 
 describe("fs.find_files", function()
   local tmpdir


### PR DESCRIPTION
## Summary

This fixes root detection for Laravel applications located inside a subdirectory of a Git repository (e.g. monorepo layouts).

## Problem

`get_root_dir()` always returns the Git repository root. This works for standard Laravel projects, but fails when the Laravel application is nested inside the repository.

For example:

```text
my-monorepo/
├── .git/
├── frontend/
└── backend/
    ├── artisan
    ├── composer.json
    ├── app/
    ├── resources/
    ├── routes/
    └── vendor/
```

When editing a file inside `backend/`, the plugin resolves:

```text
my-monorepo/
```

instead of:

```text
my-monorepo/backend/
```

As a result, health checks report missing Laravel files and features that depend on the Laravel project root cannot locate the correct resources.

## Reproduction

1. Create a Git repository with a Laravel application inside a subdirectory (e.g. `backend/`).
2. Open a Blade or PHP file inside the Laravel application.
3. Run `:checkhealth blade-nav`.

The plugin reports missing Laravel files because it resolves the Git repository root instead of the Laravel project root.

## Solution

Root detection now:

- searches upward from the current buffer for the nearest Laravel project using `artisan` as the project marker,
- falls back to the Git repository root when no Laravel project is found,
- finally falls back to the current working directory.

This preserves the existing behavior for standard Laravel projects while adding support for nested Laravel applications.

## Tests

Added test coverage for:

- nested Laravel project detection,
- Git root fallback,
- current working directory fallback,
- unnamed buffers,
- cache behavior.